### PR TITLE
fix: jwt 수정 로직에 있었던 오류 수정

### DIFF
--- a/GE/src/main/java/org/example/ge/instrastructure/security/jwt/JwtParser.java
+++ b/GE/src/main/java/org/example/ge/instrastructure/security/jwt/JwtParser.java
@@ -21,7 +21,7 @@ public class JwtParser {
         String token = req.getHeader(jwtProperties.header());
 
         if (StringUtils.hasText(token) && token.startsWith(jwtProperties.prefix()) && token.length() > 7) {
-            token = token.split(" ")[0];
+            token = token.split(" ")[1];
         }
 
         return token;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- HTTP 요청 헤더에서 토큰을 추출하는 방식이 수정되었습니다. 이제 첫 번째 요소 대신 두 번째 요소를 사용하여 토큰을 파싱합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->